### PR TITLE
Handle model compilation workflow in ModelTab

### DIFF
--- a/selfdrive/ui/qt/custom/custom.h
+++ b/selfdrive/ui/qt/custom/custom.h
@@ -11,6 +11,8 @@
 #include <QWidget>
 #include <QTimer>
 
+class QProcess;
+
 #include <QJsonObject>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -337,6 +339,9 @@ public:
 
 private:
   std::map<std::string, CValueControl*> m_valueCtrl;
+  QString currentModel;
+  ButtonControl *changeModelButton = nullptr;
+  QProcess *modelProcess = nullptr;
 
 
 protected:


### PR DESCRIPTION
## Summary
- keep the active model selection and associated button accessible inside ModelTab
- disable the selector while launching the Windows python build process and update the UI state
- handle process completion to restore button state, update Params, and capture build logs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e075a86b94832a82284d9f440deef9